### PR TITLE
Use workaround for qsize not implemented on Mac OSX

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,8 +27,13 @@ dist/*
 # test
 htmlcov
 .coverage
-covergage.xml
+coverage.xml
 
 # doc
 docs/_build
 docs/apidocs
+
+#pycharm
+.idea
+
+

--- a/deeprank_gnn/preprocess.py
+++ b/deeprank_gnn/preprocess.py
@@ -101,12 +101,24 @@ class PreProcessor:
             if not process.is_alive():
                 raise RuntimeError(f"worker process {process.name} did not start")
 
+    def _queue_empty(self):
+        """
+        Returns whether queue is empty.
+
+        Note: This implementation is not reliable, especially not on Mac OSX .qsize() seems to be more reliable than
+        .empty(), however qsize relies on sem_getvalue() which is not implemented on Mac OSX.
+        """
+        try:
+            return self._input_queue.qsize() == 0
+        except NotImplementedError:
+            return self._input_queue.empty()
+
     def wait(self):
         "wait for all graphs to be built"
 
         try:
             _log.info("waiting for the queue to be empty..")
-            while self._input_queue.qsize() > 0:  # qsize seems to be more reliable than the empty method
+            while not self._queue_empty():
                 sleep(1.0)
         finally:
             self.shutdown()

--- a/deeprank_gnn/preprocess.py
+++ b/deeprank_gnn/preprocess.py
@@ -105,7 +105,7 @@ class PreProcessor:
         """
         Returns whether queue is empty.
 
-        Note: This implementation is not reliable, especially not on Mac OSX .qsize() seems to be more reliable than
+        Note: This implementation is not reliable, especially not on Mac OSX. .qsize() seems to be more reliable than
         .empty(), however qsize relies on sem_getvalue() which is not implemented on Mac OSX.
         """
         try:

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -7,9 +7,17 @@ import h5py
 from deeprank_gnn.preprocess import PreProcessor
 from deeprank_gnn.models.query import SingleResidueVariantResidueQuery
 from deeprank_gnn.domain.amino_acid import alanine, phenylalanine
+from tests.utils import PATH_TEST
 
 
 def test_preprocess():
+    """
+    Tests preprocessing several PDB files into their feature representation HDF5 file.
+
+    NB: This test sometimes fails, especially on Mac OSX. The PreProcessor class relies on python multiprocessing
+    library's Queue. We need to check whether the queue is empty, which is not always reliable, the only working
+    implementation on Mac OSX is really not reliable.
+    """
 
     output_directory = mkdtemp()
 
@@ -22,10 +30,11 @@ def test_preprocess():
         count_queries = 100
         queries = []
         for number in range(1, count_queries + 1):
-            query = SingleResidueVariantResidueQuery("tests/data/pdb/101M/101M.pdb", "A", number, None,
-                                                     alanine, phenylalanine,
-                                                     pssm_paths={"A": "tests/data/pssm/101M/101M.A.pdb.pssm"},
-                                                     variant_conservation=0.0, wildtype_conservation=0.0)
+            query = SingleResidueVariantResidueQuery(
+                str(PATH_TEST / "data/pdb/101M/101M.pdb"), "A", number, None,
+                alanine, phenylalanine,
+                pssm_paths={"A": str(PATH_TEST / "data/pssm/101M/101M.A.pdb.pssm")},
+                variant_conservation=0.0, wildtype_conservation=0.0)
             preprocessor.add_query(query)
             queries.append(query)
 


### PR DESCRIPTION
Fixes #55 

This at least does an attempt to have something working on OSX, although we know that when using `.empty()` we already stop while some jobs are still running. This will be fixed with #56.